### PR TITLE
ts: Convert linkifiers.js to TypeScript.

### DIFF
--- a/web/src/linkifiers.ts
+++ b/web/src/linkifiers.ts
@@ -2,11 +2,17 @@ import * as blueslip from "./blueslip";
 
 const linkifier_map = new Map(); // regex -> url
 
-export function get_linkifier_map() {
+type Linkifier = {
+    pattern: string;
+    url_format: string;
+    id: number;
+};
+
+export function get_linkifier_map(): Map<RegExp, string> {
     return linkifier_map;
 }
 
-function python_to_js_linkifier(pattern, url) {
+function python_to_js_linkifier(pattern: string, url: string): [RegExp | null, string] {
     // Converts a python named-group regex to a javascript-compatible numbered
     // group regex... with a regex!
     const named_group_re = /\(?P<([^>]+?)>/g;
@@ -17,7 +23,7 @@ function python_to_js_linkifier(pattern, url) {
         // Replace named group with regular matching group
         pattern = pattern.replace("(?P<" + name + ">", "(");
         // Replace named reference in URL to numbered reference
-        url = url.replace("%(" + name + ")s", "\\" + current_group);
+        url = url.replace("%(" + name + ")s", `\\${current_group}`);
 
         // Reset the RegExp state
         named_group_re.lastIndex = 0;
@@ -59,12 +65,14 @@ function python_to_js_linkifier(pattern, url) {
         // We have an error computing the generated regex syntax.
         // We'll ignore this linkifier for now, but log this
         // failure for debugging later.
-        blueslip.error("python_to_js_linkifier: " + error.message);
+        if (error instanceof SyntaxError) {
+            blueslip.error("python_to_js_linkifier: " + error.message);
+        }
     }
     return [final_regex, url];
 }
 
-export function update_linkifier_rules(linkifiers) {
+export function update_linkifier_rules(linkifiers: Linkifier[]): void {
     linkifier_map.clear();
 
     for (const linkifier of linkifiers) {
@@ -78,6 +86,6 @@ export function update_linkifier_rules(linkifiers) {
     }
 }
 
-export function initialize(linkifiers) {
+export function initialize(linkifiers: Linkifier[]): void {
     update_linkifier_rules(linkifiers);
 }


### PR DESCRIPTION
This converts `linkifers.js` to TypeScript.


<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [X] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [X] Explains differences from previous plans (e.g., issue description).
- [X] Highlights technical choices and bugs encountered.
- [X] Calls out remaining decisions and concerns.
- [X] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [X] Each commit is a coherent idea.
- [X] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [X] Visual appearance of the changes.
- [X] Responsiveness and internationalization.
- [X] Strings and tooltips.
- [X] End-to-end functionality of buttons, interactions and flows.
- [X] Corner cases, error conditions, and easily imagined bugs.
</details>
