### PR TITLE
ts: Convert portico/teams.js to TypeScript.

### DIFF
--- a/web/src/portico/landing-page.js
+++ b/web/src/portico/landing-page.js
@@ -5,6 +5,7 @@ import microsoft_image from "../../images/app-screenshots/microsoft.png";
 import ubuntu_image from "../../images/app-screenshots/ubuntu.png";
 import android_image from "../../images/app-screenshots/zulip-android.png";
 import iphone_image from "../../images/app-screenshots/zulip-iphone-rough.png";
+import {page_params} from "../page_params";
 
 import {detect_user_os} from "./tabbed-instructions";
 import render_tabs from "./team";
@@ -194,7 +195,9 @@ $(() => {
     events();
 
     if (window.location.pathname === "/team/") {
-        render_tabs();
+        const contributors = page_params.contributors;
+        delete page_params.contributors;
+        render_tabs(contributors);
     }
 
     // Source: https://stackoverflow.com/questions/819416/adjust-width-and-height-of-iframe-to-fit-with-content-in-it

--- a/web/src/portico/team.js
+++ b/web/src/portico/team.js
@@ -27,7 +27,7 @@ function calculate_total_commits(contributor) {
     return commits;
 }
 
-function get_profile_url(contributor, tab_name) {
+function get_profile_url(contributor) {
     const commit_email_linked_to_github = "github_username" in contributor;
 
     if (commit_email_linked_to_github) {
@@ -35,10 +35,6 @@ function get_profile_url(contributor, tab_name) {
     }
 
     const email = contributor.email;
-
-    if (tab_name) {
-        return `https://github.com/zulip/${tab_name}/commits?author=${email}`;
-    }
 
     for (const repo_name in repo_name_to_tab_name) {
         if (repo_name in contributor) {


### PR DESCRIPTION
This PR converts `portico/teams.js` to TypeScript.

To convert `portico/teams.js`, `contributors` property had to be added to `page_params` in `page_params.ts`.


<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
