### PR TITLE
js: Break cyclic dependency b/w top_left_corner and unread_ui.

### DIFF
--- a/web/src/top_left_corner.js
+++ b/web/src/top_left_corner.js
@@ -2,7 +2,8 @@ import $ from "jquery";
 
 import * as resize from "./resize";
 import * as ui_util from "./ui_util";
-import * as unread_ui from "./unread_ui";
+
+let last_mention_count = 0;
 
 export function update_starred_count(count) {
     const $starred_li = $(".top_left_starred_messages");
@@ -19,7 +20,7 @@ export function update_dom_with_unread_counts(counts) {
     ui_util.update_unread_count_in_dom($mentioned_li, counts.mentioned_message_count);
     ui_util.update_unread_count_in_dom($home_li, counts.home_unread_messages);
 
-    unread_ui.animate_mention_changes($mentioned_li, counts.mentioned_message_count);
+    animate_mention_changes($mentioned_li, counts.mentioned_message_count);
 }
 
 function remove($elem) {
@@ -77,4 +78,24 @@ export function narrow_to_recent_topics() {
     setTimeout(() => {
         resize.resize_stream_filters_container();
     }, 0);
+}
+
+export function animate_mention_changes($li, new_mention_count) {
+    if (new_mention_count > last_mention_count) {
+        do_new_messages_animation($li);
+    }
+    last_mention_count = new_mention_count;
+}
+
+function do_new_messages_animation($li) {
+    $li.addClass("new_messages");
+    function mid_animation() {
+        $li.removeClass("new_messages");
+        $li.addClass("new_messages_fadeout");
+    }
+    function end_animation() {
+        $li.removeClass("new_messages_fadeout");
+    }
+    setTimeout(mid_animation, 3000);
+    setTimeout(end_animation, 6000);
 }

--- a/web/src/unread_ui.js
+++ b/web/src/unread_ui.js
@@ -13,7 +13,6 @@ import * as topic_list from "./topic_list";
 import * as unread from "./unread";
 import {notify_server_messages_read} from "./unread_ops";
 
-let last_mention_count = 0;
 let user_closed_mark_as_read_turned_off_banner = false;
 export function hide_mark_as_read_turned_off_banner() {
     // Use visibility instead of hide() to prevent messages on the screen from
@@ -30,26 +29,6 @@ export function notify_messages_remain_unread() {
     if (!user_closed_mark_as_read_turned_off_banner) {
         $("#mark_as_read_turned_off_banner").toggleClass("invisible", false);
     }
-}
-
-function do_new_messages_animation($li) {
-    $li.addClass("new_messages");
-    function mid_animation() {
-        $li.removeClass("new_messages");
-        $li.addClass("new_messages_fadeout");
-    }
-    function end_animation() {
-        $li.removeClass("new_messages_fadeout");
-    }
-    setTimeout(mid_animation, 3000);
-    setTimeout(end_animation, 6000);
-}
-
-export function animate_mention_changes($li, new_mention_count) {
-    if (new_mention_count > last_mention_count) {
-        do_new_messages_animation($li);
-    }
-    last_mention_count = new_mention_count;
 }
 
 export function set_count_toggle_button($elem, count) {


### PR DESCRIPTION
This PR breaks the cyclic dependency between `top_left_corner.js` and `unread_ui.js`.

It achieves this by shifting the `animate_mention_changes` function from `unread_ui.js` to `top_left_corner.js`.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [X] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [X] Each commit is a coherent idea.
- [X] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
