### PR TITLE
select_recipient_widget: Use "button" tag instead of "div".

### DIFF
--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -526,6 +526,7 @@ input.recipient_box {
 #compose_select_recipient_widget {
     border-radius: 0 4px 4px 0;
     width: auto;
+    outline: none;
 }
 
 #stream_message_recipient_topic.recipient_box {

--- a/web/templates/compose.hbs
+++ b/web/templates/compose.hbs
@@ -58,12 +58,12 @@
                             <a role="button" class="narrow_to_compose_recipients zulip-icon zulip-icon-arrow-left-circle order-1" data-tooltip-template-id="narrow_to_compose_recipients_tooltip"></a>
                             <div id="compose_recipient_selection_dropdown" class="new-style" tabindex="0">
                                 <div class="stream_header_colorblock"></div>
-                                <div id="compose_select_recipient_widget" class="dropdown-widget-button" role="button">
+                                <button id="compose_select_recipient_widget" class="dropdown-widget-button" type="button">
                                     <span id="compose_select_recipient_name">
                                         {{t 'Select a stream'}}
                                     </span>
                                     <i class="fa fa-chevron-down"></i>
-                                </div>
+                                </button>
                             </div>
                             <i class="fa fa-angle-right" aria-hidden="true"></i>
                             <input type="text" class="recipient_box" name="stream_message_recipient_topic" id="stream_message_recipient_topic" maxlength="{{ max_topic_length }}" value="" placeholder="{{t 'Topic' }}" autocomplete="off" tabindex="0" aria-label="{{t 'Topic' }}" />


### PR DESCRIPTION

This PR changes the `select_recipient_widget` inside the compose section to use a `button` tag instead of `div`. This makes sure that when the user hovers over the select recipient button a hand pointer is shown instead of mouse/text pointer.

Fixes #25592.

<hr>

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>

<summary> Before </summary>

![Before](https://github.com/sbansal1999/zulip/assets/35286603/b0ec6689-698d-40ec-ace7-04049f565ed0)

</details>

<details>

<summary>  After </summary>

![After](https://github.com/sbansal1999/zulip/assets/35286603/3577d80e-9183-4649-9a90-259fe5ca74f2)

</details>

<hr>

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>