### PR TITLE
stream_settings: Migrate popovers to tippy. 

### DIFF
--- a/web/src/stream_ui_updates.js
+++ b/web/src/stream_ui_updates.js
@@ -46,6 +46,7 @@ export function initialize_disable_btn_hint_popover(
 export function initialize_cant_subscribe_popover(sub) {
     const $button_wrapper = stream_settings_containers
         .get_edit_container(sub)
+        .parent()
         .find(".sub_unsub_button_wrapper");
     const $settings_button = stream_settings_ui.settings_button_for_sub(sub);
     initialize_disable_btn_hint_popover(

--- a/web/src/stream_ui_updates.js
+++ b/web/src/stream_ui_updates.js
@@ -15,12 +15,7 @@ import * as stream_edit from "./stream_edit";
 import * as stream_settings_containers from "./stream_settings_containers";
 import * as stream_settings_ui from "./stream_settings_ui";
 
-export function initialize_disable_btn_hint_popover(
-    $btn_wrapper,
-    $popover_btn,
-    $disabled_btn,
-    hint_text,
-) {
+export function initialize_disable_btn_hint_popover($btn_wrapper, hint_text) {
     tippy($btn_wrapper[0], {
         content: hint_text,
         animation: false,
@@ -34,11 +29,8 @@ export function initialize_cant_subscribe_popover(sub) {
         .get_edit_container(sub)
         .parent()
         .find(".sub_unsub_button_wrapper");
-    const $settings_button = stream_settings_ui.settings_button_for_sub(sub);
     initialize_disable_btn_hint_popover(
         $button_wrapper,
-        $settings_button,
-        $settings_button,
         $t({defaultMessage: "Only stream members can add users to a private stream"}),
     );
 }
@@ -231,10 +223,6 @@ export function update_add_subscriptions_elements(sub) {
 
     // Otherwise, we adjust whether the widgets are disabled based on
     // whether this user is authorized to add subscribers.
-    const $input_element = $add_subscribers_container.find(".input").expectOne();
-    const $button_element = $add_subscribers_container
-        .find('button[name="add_subscriber"]')
-        .expectOne();
     const allow_user_to_add_subs = sub.can_add_subscribers;
 
     enable_or_disable_add_subscribers_elements($add_subscribers_container, allow_user_to_add_subs);
@@ -251,12 +239,7 @@ export function update_add_subscriptions_elements(sub) {
                 defaultMessage: "Only stream members can add users to a private stream.",
             });
         }
-        initialize_disable_btn_hint_popover(
-            $add_subscribers_container,
-            $input_element,
-            $button_element,
-            tooltip_message,
-        );
+        initialize_disable_btn_hint_popover($add_subscribers_container, tooltip_message);
     }
 }
 

--- a/web/src/stream_ui_updates.js
+++ b/web/src/stream_ui_updates.js
@@ -1,4 +1,5 @@
 import $ from "jquery";
+import tippy from "tippy.js";
 
 import render_announce_stream_checkbox from "../templates/stream_settings/announce_stream_checkbox.hbs";
 import render_stream_privacy_icon from "../templates/stream_settings/stream_privacy_icon.hbs";
@@ -20,26 +21,11 @@ export function initialize_disable_btn_hint_popover(
     $disabled_btn,
     hint_text,
 ) {
-    // Disabled button blocks mouse events(hover) from reaching
-    // to it's parent div element, so popover don't get triggered.
-    // Add css to prevent this.
-    $disabled_btn.css("pointer-events", "none");
-    $popover_btn.popover({
-        placement: "bottom",
-        content: $("<div>").addClass("sub_disable_btn_hint").text(hint_text).prop("outerHTML"),
-        trigger: "manual",
-        html: true,
+    tippy($btn_wrapper[0], {
+        content: hint_text,
         animation: false,
-    });
-
-    $btn_wrapper.on("mouseover", (e) => {
-        $popover_btn.popover("show");
-        e.stopPropagation();
-    });
-
-    $btn_wrapper.on("mouseout", (e) => {
-        $popover_btn.popover("hide");
-        e.stopPropagation();
+        hideOnClick: false,
+        placement: "bottom",
     });
 }
 
@@ -104,7 +90,7 @@ export function update_settings_button_for_sub(sub) {
     }
     if (stream_data.can_toggle_subscription(sub)) {
         $settings_button.prop("disabled", false);
-        $settings_button.popover("destroy");
+        $settings_button.parent()[0]._tippy?.destroy();
         $settings_button.css("pointer-events", "");
     } else {
         $settings_button.attr("title", "");
@@ -292,13 +278,14 @@ export function enable_or_disable_add_subscribers_elements(
     const $add_subscribers_button = $container_elem
         .find('button[name="add_subscriber"]')
         .expectOne();
+    const $add_subscribers_container = $(".edit_subscribers_for_stream .subscriber_list_settings");
 
     $input_element.prop("contenteditable", enable_elem);
     $add_subscribers_button.prop("disabled", !enable_elem);
 
     if (enable_elem) {
         $add_subscribers_button.css("pointer-events", "");
-        $input_element.popover("destroy");
+        $add_subscribers_container[0]?._tippy?.destroy();
         $container_elem.find(".add_subscribers_container").removeClass("add_subscribers_disabled");
     } else {
         $container_elem.find(".add_subscribers_container").addClass("add_subscribers_disabled");

--- a/web/src/user_group_ui_updates.js
+++ b/web/src/user_group_ui_updates.js
@@ -37,7 +37,7 @@ export function update_add_members_elements(group) {
         $input_element.prop("disabled", false);
         $button_element.prop("disabled", false);
         $button_element.css("pointer-events", "");
-        $input_element.popover("destroy");
+        $add_members_container[0]._tippy?.destroy();
     } else {
         $input_element.prop("disabled", true);
         $button_element.prop("disabled", true);

--- a/web/src/user_group_ui_updates.js
+++ b/web/src/user_group_ui_updates.js
@@ -44,8 +44,6 @@ export function update_add_members_elements(group) {
 
         stream_ui_updates.initialize_disable_btn_hint_popover(
             $add_members_container,
-            $input_element,
-            $button_element,
             $t({defaultMessage: "Only group members can add users to a group."}),
         );
     }


### PR DESCRIPTION
This pull request migrates tooltips created in `stream_ui_updates.js` to use `tippy.js` instead of Bootstrap popovers. Manual testing has been done for all tooltips created in the above-mentioned file.

It also fixes a bug in which no tooltip was shown when the `Subscribe` button for a private stream was disabled.

Fixes: #25627

- To test the `Add Subscribers` and `Disabled Subscriber Button` tooltips, first log in as an `Administrator` and then create a private stream with members being you and some more people. Now, Unsubscribe yourself from that stream. After this, if you hover over the subscribe button you will be able to see the tooltip. Click on the `Subscribe` tab on that same window and now you can see the disabled input and the `Add` button, hover over these to see the tooltip.

- To test the `Add Group Members` tooltip, you need to visit the window manually as the group overlay is still in construction (#24766). To visit it, go to [this](http://localhost:9991/#groups) link. You can log in as a normal user to see the tooltip. Click on any group name and then on `Members`, there you can test the tooltip.

<hr/>

**Screenshots and Screen Captures:**

<details>
<summary> Add Subscribers </summary>

| Before | After |
|--------|--------|
| ![Add sub before](https://github.com/sbansal1999/zulip/assets/35286603/d6b1c2c7-dd78-4592-928c-659c37d8f030) | ![Add sub after (1)](https://github.com/sbansal1999/zulip/assets/35286603/b0277781-a68a-4187-a4c6-d0c4f226d65d) | 
</details>

<details>
<summary> Disabled Subsrcibe Button </summary>

| Before | After |
|--------|--------|
| ![Subscribe Before](https://github.com/sbansal1999/zulip/assets/35286603/252cb32a-7b85-4b06-8a8a-22aec240dd97) | ![Subscribe After](https://github.com/sbansal1999/zulip/assets/35286603/f3c1b66d-52da-4b2a-a31d-a8d8012cece2) |

</details>

<details>
<summary> Add Group Members</summary>

| Before | After |
|--------|--------|
| ![Groups before](https://github.com/sbansal1999/zulip/assets/35286603/462dedb9-2e49-493b-91ae-63ef68b567d6) | ![Groups After](https://github.com/sbansal1999/zulip/assets/35286603/1cfc4fc8-5c3e-480f-9f90-40d83eddf894) |
</details>

<hr/>

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
