### PR TITLE
tools: Copy "assets" subdirectory of bots to "static/generated/bots/".

### DIFF
--- a/tools/setup/generate_zulip_bots_static_files.py
+++ b/tools/setup/generate_zulip_bots_static_files.py
@@ -23,11 +23,17 @@ def generate_zulip_bots_static_files() -> None:
 
     os.makedirs(bots_dir, exist_ok=True)
 
-    def copyfiles(paths: List[str]) -> None:
+    def copyfiles(paths: List[str], are_assets: bool = False) -> None:
         for src_path in paths:
-            bot_name = os.path.basename(os.path.dirname(src_path))
+            if are_assets:
+                bot_name = os.path.basename(os.path.dirname(os.path.dirname(src_path)))
+                bot_dir = os.path.join(
+                    bots_dir, bot_name, os.path.basename(os.path.dirname(src_path))
+                )
+            else:
+                bot_name = os.path.basename(os.path.dirname(src_path))
+                bot_dir = os.path.join(bots_dir, bot_name)
 
-            bot_dir = os.path.join(bots_dir, bot_name)
             os.makedirs(bot_dir, exist_ok=True)
 
             dst_path = os.path.join(bot_dir, os.path.basename(src_path))
@@ -43,6 +49,10 @@ def generate_zulip_bots_static_files() -> None:
     doc_glob_pattern = os.path.join(package_bots_dir, "*/doc.md")
     docs = glob.glob(doc_glob_pattern)
     copyfiles(docs)
+
+    assets_glob_pattern = os.path.join(package_bots_dir, "*/assets/*")
+    assets = glob.glob(assets_glob_pattern)
+    copyfiles(assets, are_assets=True)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR adds code to copy `assets` subdirectory of individual bots that are present in our `python-zulip-api` repository to `static/generated/bots/` folder. This is required as the documentation of some integrations require these asssets but are not being loaded due to the absence of the `assets` in their directory.

For eg. `zulip_bots/zulip_bots/bots/xkcd/assets/xkcd-help.png` will be copied to `/static/generated/bots/xkcd/assets/xkcd-help.png` 

- Some changes were required to the `copyfiles` function as unlike `doc.md` the images are present inside `assets` subdirectory.

CZO Discussion: [Link](https://chat.zulip.org/#narrow/stream/9-issues/topic/http.20500.20in.20xkcd.20bot.20docs)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
