### PR TITLE
integrations: Update documentation for Grafana Integration.

### DIFF
--- a/zerver/webhooks/grafana/doc.md
+++ b/zerver/webhooks/grafana/doc.md
@@ -4,6 +4,29 @@ See your Grafana dashboard alerts in Zulip!
 
 1. {!create-bot-construct-url.md!}
 
+### Instructions for Grafana 8.3 and above
+
+1. In Grafana, go to **Alerting**. Click on **Contact points**, and
+   then **Add contact point**.  Configure the new contact point as
+   follows: set the name; under **Integration** choose Webhook, and
+   set **URL** to the URL constructed above; under **Optional Webhook
+   settings** choose **POST** as the **HTTP method**.  Click on
+   **Test** to send a test notification and if all is good, click on
+   **Save contact point**.
+1. Under **Notification policies** create a new policy (for example, a
+   **New nested policy** of the **Default policy**), setting the
+   **Matching label** as **Zulip** = 1, and selecting the **Contact
+   point** as the one created in the step above. Click on **Save
+   policy**.
+1. Under **Alert rules**, click on **Create alert rule**, where you
+   will specify the conditions to fire the alert. Make sure you set
+   the **Rule name**, and in the **Notifications** section add a label
+   that matches the label created in the step above. Customize the
+   **query and alert condition**, **alert evaluation behavior**, etc.
+   and click on **Save rule**.
+
+### Instructions for Grafana 8.2 and below
+
 1. In Grafana, go to **Alerting**. Click on **Notification channels**.
    Configure **Edit Notification Channel** as appropriate for your
    alert notification. Set the name. Under **Type**, choose **webhook**.


### PR DESCRIPTION
This updates the documentation for Grafana Integration -- the process for creating an integration has changed since Grafana 8.3.

<details>

<summary> <b>Screenshots:</b> </summary>

| Before | After |
|---|---|
|![image](https://github.com/sbansal1999/zulip/assets/35286603/89baf286-a1c8-4f77-9a16-f570f909908c) | ![Screenshot from 2023-06-20 01-01-48](https://github.com/sbansal1999/zulip/assets/35286603/8f5b8b4b-37cd-456b-9dbe-07c99a6522fa)
|![image](https://github.com/sbansal1999/zulip/assets/35286603/73143919-4125-416c-a259-69f2c40a282d)|![Screenshot from 2023-06-20 01-01-58](https://github.com/sbansal1999/zulip/assets/35286603/40bf3908-d12b-4c0c-be8b-2404d26d2ef7) |


</details>

<!-- Describe your pull request here.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->



<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x]
      [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code)
      the changes for clarity and maintainability (variable names,
      code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue
  description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit
discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
