### PR TITLE
bot-settings: Add modal to generate Integration URL.

### DIFF
--- a/api_docs/changelog.md
+++ b/api_docs/changelog.md
@@ -20,6 +20,11 @@ format used by the Zulip server that they are interacting with.
 
 ## Changes in Zulip 8.0
 
+**Feature level 192**
+
+* [`POST /register`](/api/register-queue): Added `display_name` and
+  `all_event_types` fields to the `realm_incoming_webhook_bots` object.
+
 **Feature level 191**
 
 * [`GET /events`](/api/get-events), [`POST /register`](/api/register-queue),

--- a/templates/zerver/integrations/include/create-bot-construct-url.md
+++ b/templates/zerver/integrations/include/create-bot-construct-url.md
@@ -1,20 +1,8 @@
 {!create-an-incoming-webhook.md!}
 
-Construct the URL for the {{ integration_display_name }}
-bot using the bot's API key and the desired stream name:
-
-{!webhook-url.md!}
-
-Modify the parameters of the URL above, where `api_key` is the API key
-of your Zulip bot, and `stream` is the [URL-encoded][url-encoder]
-stream name you want the notifications sent to. If you don't specify a
-`stream`, the bot will send notifications via direct messages to the
-creator of the bot.
-
-If you'd like this integration to always send notifications to a
-specific topic in the specified stream, just include the
-[URL-encoded][url-encoder] topic as an additional parameter. E.g.,
-for `your topic`, append `&topic=your%20topic` to the URL.
+Generate the URL for your integration by clicking the **link** (<i
+class="fa fa-link"></i>) icon on the profile card for the bot you
+created.
 
 {% if all_event_types is defined %}
 
@@ -22,4 +10,3 @@ for `your topic`, append `&topic=your%20topic` to the URL.
 
 {% endif %}
 
-[url-encoder]: https://www.urlencoder.org/

--- a/version.py
+++ b/version.py
@@ -33,7 +33,7 @@ DESKTOP_WARNING_VERSION = "5.9.3"
 # Changes should be accompanied by documentation explaining what the
 # new level means in api_docs/changelog.md, as well as "**Changes**"
 # entries in the endpoint's documentation in `zulip.yaml`.
-API_FEATURE_LEVEL = 191
+API_FEATURE_LEVEL = 192
 
 # Bump the minor PROVISION_VERSION to indicate that folks should provision
 # only when going from an old version of the code to a newer version. Bump

--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -884,6 +884,7 @@
     .grey-box,
     .white-box,
     .stream-email,
+    #generate-integration-url-modal .integration-url-container,
     #settings_page .settings-header,
     #settings_page .sidebar li.active,
     #settings_page .sidebar-wrapper .tab-container,

--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -809,6 +809,10 @@ input[type="checkbox"] {
         .purple {
             color: hsl(278deg 62% 68%);
         }
+
+        .steel-blue {
+            color: hsl(207deg 44% 49%);
+        }
     }
 
     .bot-information-box {
@@ -1961,5 +1965,32 @@ $option_title_width: 180px;
         outline: 0;
         box-shadow: inset 0 1px 1px hsl(0deg 0% 0% / 7.5%),
             0 0 8px hsl(206deg 80% 62% / 60%);
+    }
+}
+
+#generate-integration-url-modal {
+    .inline {
+        display: inline;
+    }
+
+    .hide {
+        display: none;
+    }
+
+    .integration-url-container {
+        font-family: "Source Code Pro", monospace;
+        padding: 10px;
+        font-size: 0.85rem;
+        background-color: hsl(0deg 0% 98%);
+        border: 1px solid hsl(0deg 0% 87%);
+        border-radius: 4px;
+
+        .integration-url {
+            display: block;
+            margin: auto;
+            word-wrap: break-word;
+            word-break: break-all;
+            white-space: normal;
+        }
     }
 }

--- a/web/templates/settings/bot_avatar_row.hbs
+++ b/web/templates/settings/bot_avatar_row.hbs
@@ -20,6 +20,11 @@
                 <button type="submit" class="btn open_bots_subscribed_streams tippy-zulip-delayed-tooltip" data-tippy-content="{{t 'Subscribed streams' }}" data-user-id="{{user_id}}">
                     <i class="fa fa-hashtag purple" aria-hidden="true"></i>
                 </button>
+                {{#if is_incoming_webhook_bot}}
+                <button type="submit" class="btn open-generate-integration-url-modal tippy-zulip-delayed-tooltip" data-tippy-content="{{t 'Generate URL for an integration'}}" data-api-key="{{api_key}}">
+                    <i class="fa fa-link steel-blue" aria-hidden="true"></i>
+                </button>
+                {{/if}}
             </div>
             {{/if}}
         </div>

--- a/web/templates/settings/edit_bot_form.hbs
+++ b/web/templates/settings/edit_bot_form.hbs
@@ -47,6 +47,13 @@
             <div><label for="edit_bot_avatar_file" generated="true" class="edit_bot_avatar_error text-error"></label></div>
         </div>
     </form>
+    {{#if is_incoming_webhook_bot}}
+    <div class="input-group new-style">
+        <button class="button rounded generate_url_for_integration">
+            {{t 'Generate URL for an integration' }}
+        </button>
+    </div>
+    {{/if}}
     <div class="input-group new-style">
         <button class="button rounded btn-danger deactivate_bot_button">
             {{t 'Deactivate bot' }}

--- a/web/templates/settings/generate_integration_url_modal.hbs
+++ b/web/templates/settings/generate_integration_url_modal.hbs
@@ -1,0 +1,42 @@
+<div class="new-style">
+    <div class="input-group">
+        <label for="integration-name">{{t "Integration"}}</label>
+        <input type="text" id="integration-name" autocomplete="off"/>
+    </div>
+    <div class="input-group">
+        <label for="stream-name">{{t "Stream to use for notifications (optional)"}}</label>
+        <select id="stream-name" class="modal_select update-url">
+            <option value="">{{t "Select stream"}}</option>
+            {{#each streams}}
+                <option>{{this}}</option>
+            {{/each}}
+        </select>
+        <p>{{t "If you do not specify a stream, the bot will send notifications via PMs to the creator of the bot."}}</p>
+    </div>
+    <div class="input-group override-topic-group control-label-disabled">
+        <label class="checkbox">
+            <input
+              type="checkbox"
+              id="override-topic"
+              class="update-url"
+              disabled
+              />
+            <span></span>
+        </label>
+        <label class="inline" for="override-topic">
+            {{t "Override topic for notifications?"}}
+        </label>
+        <p>{{t "If selected, all notifications will be sent to a single topic of your choice."}}</p>
+    </div>
+    <div class="input-group topic-input hide">
+        <label for="topic-name">{{t "Topic"}}</label>
+        <input type="text" id="topic-name" class="update-url" />
+    </div>
+    <hr />
+    <p class="integration-url-header">{{t "URL for your integration"}}</p>
+    <div class="integration-url-container">
+        <div class="integration-url">
+            {{default_message}}
+        </div>
+    </div>
+</div>

--- a/zerver/lib/events.py
+++ b/zerver/lib/events.py
@@ -22,7 +22,11 @@ from zerver.lib.compatibility import is_outdated_server
 from zerver.lib.exceptions import JsonableError
 from zerver.lib.external_accounts import get_default_external_accounts
 from zerver.lib.hotspots import get_next_hotspots
-from zerver.lib.integrations import EMBEDDED_BOTS, WEBHOOK_INTEGRATIONS
+from zerver.lib.integrations import (
+    EMBEDDED_BOTS,
+    WEBHOOK_INTEGRATIONS,
+    get_all_event_types,
+)
 from zerver.lib.message import (
     add_message_to_unread_msgs,
     aggregate_unread_data,
@@ -506,6 +510,8 @@ def fetch_initial_state_data(
             realm_incoming_webhook_bots.append(
                 {
                     "name": integration.name,
+                    "display_name": integration.display_name,
+                    "all_event_types": get_all_event_types(integration),
                     "config": {c[1]: c[0] for c in integration.config_options},
                 }
             )

--- a/zerver/lib/integrations.py
+++ b/zerver/lib/integrations.py
@@ -831,3 +831,12 @@ DOC_SCREENSHOT_CONFIG: Dict[str, List[BaseScreenshotConfig]] = {
         )
     ],
 }
+
+
+def get_all_event_types(integration: Integration) -> Optional[List[str]]:
+    integration = INTEGRATIONS[integration.name]
+    if isinstance(integration, WebhookIntegration) and hasattr(
+        integration.function, "_all_event_types"
+    ):
+        return integration.function._all_event_types
+    return None

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -11436,7 +11436,7 @@ paths:
                             name:
                               type: string
                               description: |
-                                The name of the bot.
+                                The name of the bot that is internally used by Zulip.
                             display_name:
                               type: string
                               description: |

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -11437,6 +11437,24 @@ paths:
                               type: string
                               description: |
                                 The name of the bot.
+                            display_name:
+                              type: string
+                              description: |
+                                The name of the bot that is displayed to the users.
+
+                                **Changes**: New in Zulip 8.0 (feature level 192).
+                            all_event_types:
+                              type: array
+                              items:
+                                type: string
+                              nullable: true
+                              description: |
+                                The event types that are supported by the bot.
+
+                                A `null` value means that the bot does not make use of the
+                                event types feature.
+
+                                **Changes**: New in Zulip 8.0 (feature level 192).
                             config:
                               $ref: "#/components/schemas/Config"
                       recent_private_conversations:

--- a/zerver/views/documentation.py
+++ b/zerver/views/documentation.py
@@ -18,6 +18,7 @@ from zerver.lib.integrations import (
     META_CATEGORY,
     HubotIntegration,
     WebhookIntegration,
+    get_all_event_types,
 )
 from zerver.lib.request import REQ, RequestNotes, has_request_variables
 from zerver.lib.subdomains import get_subdomain
@@ -311,11 +312,9 @@ def integration_doc(request: HttpRequest, integration_name: str = REQ()) -> Http
     context["recommended_stream_name"] = integration.stream_name
     if isinstance(integration, WebhookIntegration):
         context["integration_url"] = integration.url[3:]
-        if (
-            hasattr(integration.function, "_all_event_types")
-            and integration.function._all_event_types is not None
-        ):
-            context["all_event_types"] = integration.function._all_event_types
+        all_event_types = get_all_event_types(integration)
+        if all_event_types is not None:
+            context["all_event_types"] = all_event_types
     if isinstance(integration, HubotIntegration):
         context["hubot_docs_url"] = integration.hubot_docs_url
 


### PR DESCRIPTION
This PR adds a modal that makes it easier to generate an Integration URL. The original issue also says about creating a checkbox UI for adding events that will be used to filter notifications -- I think that can be added in a follow-up PR.

The modal can be accessed through the `Bots` section in `Personal Settings` and also from the `Edit bot` menu for 
`Incoming webhook` bots only as it doesn't make sense to create Integration URLs for other types of bots.

To access the names of all the integration -- `display_name` and `all_event_types` fields were added in the `realm_incoming_webhook_bots` object in `page_params`. [Link to the discussion in #api-design](https://chat.zulip.org/#narrow/stream/378-api-design/topic/integration.20display.20name)

Some thoughts that I have:

- Right now, the native dropdown has been used for selecting the stream. I wonder if something similar to the stream selector used in the compose box is required here.
- Also, due to the native dropdown being used when the stream names get very long it looks very odd.
- When the displayed URL is not valid ("Integration URL will appear here" is shown) should the `Copy URL` button be disabled?
- Also, there is no feedback when the `Copy URL` button is clicked. (#26181) Some suggestions on what can be done about this are more than welcome.

<hr>

**Screenshots and screen captures:**

Light Theme:

<details>

<summary>Link Icon to open the modal</summary>

![image](https://github.com/sbansal1999/zulip/assets/35286603/872f34c7-e80d-4ad4-a2c4-fdd48d562e59)

</details>

<details>

<summary>Button present in Edit Bot form</summary>

![image](https://github.com/sbansal1999/zulip/assets/35286603/afa4b1a3-8d3a-4ebd-b608-e8de58254c18)

</details>

<details>

<summary>Modal for generating Integration URL</summary>

![image](https://github.com/sbansal1999/zulip/assets/35286603/00da3d8c-0fb9-42a4-9049-bc63e24ca100)

</details>

<details>

<summary>Generating Integration URL</summary>

[Screencast from 06-07-23 09:17:22 PM IST.webm](https://github.com/sbansal1999/zulip/assets/35286603/ab27228e-ef3c-4556-9179-1554a6c9e60d)



</details>

<details>

<summary>Mobile view of the modal</summary>

![image](https://github.com/sbansal1999/zulip/assets/35286603/1d9ffdba-e60f-45c1-a85b-2f125fb04dd9)

</details>

<hr>

Dark Theme:

<details>

<summary>Link Icon to open the modal</summary>

![image](https://github.com/sbansal1999/zulip/assets/35286603/0d7bddc0-d144-426d-94d3-daed35c0a12e)

</details>

<details>

<summary>Modal for generating Integration URL</summary>

![image](https://github.com/sbansal1999/zulip/assets/35286603/2cd85e8a-286e-4dfd-a1d4-0f553402cd83)


</details>

<details>

<summary>Keyboard tabbing through the modal</summary>

[Screencast from 06-07-23 09:16:21 PM IST.webm](https://github.com/sbansal1999/zulip/assets/35286603/2f6149e7-25a4-4b5e-9a0e-158224aa5aa2)


</details>

<hr>

<details>

<summary>Updated integration documentation (integration supporting event types)</summary>

![image](https://github.com/sbansal1999/zulip/assets/35286603/d2facf40-f84e-4e0d-a9d1-5195dfa011e8)

</details>

<details>

<summary>Updated integration documentation (integration not supporting event types)</summary>

![image](https://github.com/sbansal1999/zulip/assets/35286603/2b7f60b6-e631-43db-bc02-f7f1f872bc3d)

</details>

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

<hr>

Fixes part of #25976.

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
