### PR TITLE
integrations: Remove label URL from GitHub issue labeled notifications.

### DIFF
--- a/zerver/lib/webhooks/git.py
+++ b/zerver/lib/webhooks/git.py
@@ -50,8 +50,10 @@ CREATE_BRANCH_MESSAGE_TEMPLATE = "{user_name} created [{branch_name}]({url}) bra
 CREATE_BRANCH_WITHOUT_URL_MESSAGE_TEMPLATE = "{user_name} created {branch_name} branch."
 REMOVE_BRANCH_MESSAGE_TEMPLATE = "{user_name} deleted branch {branch_name}."
 
-ISSUE_LABELED_OR_UNLABELED_MESSAGE_TEMPLATE = "[{user_name}]({user_url}) {action} the [{label_name}]({label_url}) label {preposition} [Issue #{id}]({url})."
-ISSUE_LABELED_OR_UNLABELED_MESSAGE_TEMPLATE_WITH_TITLE = "[{user_name}]({user_url}) {action} the [{label_name}]({label_url}) label {preposition} [Issue #{id} {title}]({url})."
+ISSUE_LABELED_OR_UNLABELED_MESSAGE_TEMPLATE = (
+    "[{user_name}]({user_url}) {action} the {label_name} label {preposition} [Issue #{id}]({url})."
+)
+ISSUE_LABELED_OR_UNLABELED_MESSAGE_TEMPLATE_WITH_TITLE = "[{user_name}]({user_url}) {action} the {label_name} label {preposition} [Issue #{id} {title}]({url})."
 
 PULL_REQUEST_OR_ISSUE_MESSAGE_TEMPLATE = "{user_name} {action} [{type}{id}]({url})"
 PULL_REQUEST_OR_ISSUE_MESSAGE_TEMPLATE_WITH_TITLE = (
@@ -282,7 +284,6 @@ def get_issue_labeled_or_unlabeled_event_message(
     url: str,
     number: int,
     label_name: str,
-    label_url: str,
     user_url: str,
     title: Optional[str] = None,
 ) -> str:
@@ -292,7 +293,6 @@ def get_issue_labeled_or_unlabeled_event_message(
         "url": url,
         "id": number,
         "label_name": label_name,
-        "label_url": label_url,
         "user_url": user_url,
         "title": title,
         "preposition": "to" if action == "added" else "from",

--- a/zerver/webhooks/github/tests.py
+++ b/zerver/webhooks/github/tests.py
@@ -179,18 +179,18 @@ class GitHubWebhookTest(WebhookTestCase):
 
     def test_issue_labeled(self) -> None:
         expected_topic = "testing-gh / issue #9 idk man"
-        expected_message = "[sbansal1999](https://github.com/sbansal1999) added the [bug](https://api.github.com/repos/sbansal1999/testing-gh/labels/bug) label to [Issue #9](https://github.com/sbansal1999/testing-gh/issues/9)."
+        expected_message = "[sbansal1999](https://github.com/sbansal1999) added the bug label to [Issue #9](https://github.com/sbansal1999/testing-gh/issues/9)."
         self.check_webhook("issues__labeled", expected_topic, expected_message)
 
     def test_issue_labeled_with_custom_topic_in_url(self) -> None:
         self.url = self.build_webhook_url(topic="notifications")
         expected_topic = "notifications"
-        expected_message = "[sbansal1999](https://github.com/sbansal1999) added the [bug](https://api.github.com/repos/sbansal1999/testing-gh/labels/bug) label to [Issue #9 idk man](https://github.com/sbansal1999/testing-gh/issues/9)."
+        expected_message = "[sbansal1999](https://github.com/sbansal1999) added the bug label to [Issue #9 idk man](https://github.com/sbansal1999/testing-gh/issues/9)."
         self.check_webhook("issues__labeled", expected_topic, expected_message)
 
     def test_issue_unlabeled(self) -> None:
         expected_topic = "testing-gh / issue #9 idk man"
-        expected_message = "[sbansal1999](https://github.com/sbansal1999) removed the [bug](https://api.github.com/repos/sbansal1999/testing-gh/labels/bug) label from [Issue #9](https://github.com/sbansal1999/testing-gh/issues/9)."
+        expected_message = "[sbansal1999](https://github.com/sbansal1999) removed the bug label from [Issue #9](https://github.com/sbansal1999/testing-gh/issues/9)."
         self.check_webhook("issues__unlabeled", expected_topic, expected_message)
 
     def test_membership_msg(self) -> None:

--- a/zerver/webhooks/github/view.py
+++ b/zerver/webhooks/github/view.py
@@ -216,7 +216,6 @@ def get_issue_labeled_or_unlabeled_body(helper: Helper) -> str:
         url=issue["html_url"].tame(check_string),
         number=issue["number"].tame(check_int),
         label_name=payload["label"]["name"].tame(check_string),
-        label_url=payload["label"]["url"].tame(check_string),
         user_url=get_sender_url(payload),
         title=issue["title"].tame(check_string) if include_title else None,
     )


### PR DESCRIPTION
The URL is not the correct one and redirects to an API page.

<!-- Describe your pull request here.-->

Fixes: <!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
