### PR TITLE
compose: Allow flatpickr to automatically choose the direction.

### DIFF
--- a/web/src/compose.js
+++ b/web/src/compose.js
@@ -734,8 +734,8 @@ export function initialize() {
                 on_timestamp_selection,
                 get_timestamp_for_flatpickr(),
                 {
-                    // place the time picker above the icon and center it horizontally
-                    position: "above center",
+                    // place the time picker wherever there is space and center it horizontally
+                    position: "auto center",
                 },
             );
         }


### PR DESCRIPTION
Previously the flatpickr was always set to show at the top but this led to it being cut off when the message was at the top of the screen -- happens only when someone is editing a message.

The `position` option change is documented [here](https://flatpickr.js.org/options/).


**Screenshots and screen captures:**

| Before | After |
|--------|--------|
| ![Screenshot from 2023-07-10 01-50-11](https://github.com/sbansal1999/zulip/assets/35286603/cef0b9a8-772b-477a-8714-fdc1d5ee7e23) | ![Screenshot from 2023-07-10 01-49-27](https://github.com/sbansal1999/zulip/assets/35286603/3e4f567d-3c00-4af1-83e9-ea1bd55952b9)  |
| ![Screenshot from 2023-07-10 01-50-00](https://github.com/sbansal1999/zulip/assets/35286603/ed93e95b-324c-4ba8-bb67-0fc75430e959) | ![Screenshot from 2023-07-10 01-49-46](https://github.com/sbansal1999/zulip/assets/35286603/fdb3d16e-e5a2-4595-8beb-88b40c228844)  |





<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [X] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [X] Each commit is a coherent idea.
- [X] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [X] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
